### PR TITLE
Add azimuthal equidistant and orthographic projections

### DIFF
--- a/Projections/az_eqd_ortho.py
+++ b/Projections/az_eqd_ortho.py
@@ -1,0 +1,59 @@
+"""
+Azimuthal Equidistant and Orthographic projections.
+All angles in degrees.
+"""
+import numpy as np
+
+
+def azimuthal_equidistant_projection(center_lon, center_lat, lon, lat):
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+    dlon = np.radians((lon - center_lon + 180) % 360 - 180)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    sin_lat = np.sin(np.radians(lat))
+    cos_lat = np.cos(np.radians(lat))
+    cos_c = sin_lat0 * sin_lat + cos_lat0 * cos_lat * np.cos(dlon)
+    c = np.arccos(np.clip(cos_c, -1.0, 1.0))
+    k = np.where(c != 0, c / np.sin(c), 1.0)
+    x = k * cos_lat * np.sin(dlon)
+    y = k * (cos_lat0 * sin_lat - sin_lat0 * cos_lat * np.cos(dlon))
+    return x, y
+
+def inverse_azimuthal_equidistant_projection(center_lon, center_lat, x, y):
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    rho = np.sqrt(x**2 + y**2)
+    c = rho
+    sin_c = np.sin(c)
+    cos_c = np.cos(c)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    lat = np.arcsin(cos_c * sin_lat0 + (y * sin_c * cos_lat0) / np.where(rho!=0, rho, 1))
+    lon = np.radians(center_lon) + np.arctan2(x * sin_c, rho * cos_lat0 * cos_c - y * sin_lat0 * sin_c)
+    return (np.degrees(lon) + 360) % 360, np.degrees(lat)
+
+def orthographic_projection(center_lon, center_lat, lon, lat):
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+    dlon = np.radians((lon - center_lon + 180) % 360 - 180)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    sin_lat = np.sin(np.radians(lat))
+    cos_lat = np.cos(np.radians(lat))
+    x = cos_lat * np.sin(dlon)
+    y = cos_lat0 * sin_lat - sin_lat0 * cos_lat * np.cos(dlon)
+    return x, y
+
+def inverse_orthographic_projection(center_lon, center_lat, x, y):
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    rho = np.sqrt(x**2 + y**2)
+    c = np.arcsin(np.clip(rho, -1.0, 1.0))
+    sin_c = np.sin(c)
+    cos_c = np.cos(c)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    lat = np.arcsin(cos_c * sin_lat0 + (y * sin_c * cos_lat0) / np.where(rho!=0, rho, 1))
+    lon = np.radians(center_lon) + np.arctan2(x * sin_c, rho * cos_lat0 * cos_c - y * sin_lat0 * sin_c)
+    return (np.degrees(lon) + 360) % 360, np.degrees(lat)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # AstroCoordProjection
+
+This repository demonstrates several azimuthal map projections used in astronomy.  Implementations are provided in Python with reference code in C, C++ and Fortran.
+
+## Implemented projections / 已实现投影
+
+- **Gnomonic projection** (`gnomonic_projection`, `inverse_gnomonic_projection`)
+- **Azimuthal equidistant projection** (`azimuthal_equidistant_projection`, `inverse_azimuthal_equidistant_projection`)
+- **Orthographic projection** (`orthographic_projection`, `inverse_orthographic_projection`)
+
+## Usage / 用法
+
+All angles are in degrees.  The forward functions convert longitude and latitude into planar \(x, y\) coordinates relative to a chosen projection center.  The inverse functions recover spherical coordinates from those plane values.
+
+```
+from Gnomonic.gnomonic import gnomonic_projection
+from Projections.az_eqd_ortho import azimuthal_equidistant_projection
+
+center_lon, center_lat = 0.0, 90.0
+lon, lat = [120.0], [45.0]
+xi, eta = gnomonic_projection(center_lon, center_lat, lon, lat)
+```
+
+### C/C++/Fortran
+
+Simple implementations of the same algorithms are provided in `c/`, `cpp/` and `fortran/` directories for reference.

--- a/c/projections.c
+++ b/c/projections.c
@@ -1,0 +1,89 @@
+#include <math.h>
+#include <stdio.h>
+
+/* Convert degrees to radians */
+static double rad(double d){ return d * M_PI / 180.0; }
+/* Convert radians to degrees */
+static double deg(double r){ return r * 180.0 / M_PI; }
+
+void gnomonic_projection(double clon, double clat, double lon, double lat, double *x, double *y){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    double denom = sinlat * sinlat0 + coslat * coslat0 * cos(dlon);
+    *x = coslat * sin(dlon) / denom;
+    *y = (sinlat * coslat0 - coslat * sinlat0 * cos(dlon)) / denom;
+}
+
+void inverse_gnomonic_projection(double clon, double clat, double x, double y, double *lon, double *lat){
+    double lat0 = rad(clat);
+    double sinlat0 = sin(lat0);
+    double coslat0 = cos(lat0);
+    double denom = coslat0 - y * sinlat0;
+    double lam = atan2(x, denom);
+    *lon = fmod(deg(lam) + clon + 360.0, 360.0);
+    double numerator = (y * coslat0 + sinlat0) * cos(lam);
+    *lat = deg(atan(numerator / denom));
+}
+
+void azimuthal_equidistant_projection(double clon, double clat, double lon, double lat, double *x, double *y){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    double cosc = sinlat0*sinlat + coslat0*coslat*cos(dlon);
+    if(cosc>1) cosc=1; if(cosc<-1) cosc=-1;
+    double c = acos(cosc);
+    double k = (c!=0.0)? c/sin(c):1.0;
+    *x = k * coslat * sin(dlon);
+    *y = k * (coslat0*sinlat - sinlat0*coslat*cos(dlon));
+}
+
+void inverse_azimuthal_equidistant_projection(double clon, double clat, double x, double y, double *lon, double *lat){
+    double rho = hypot(x,y);
+    double c = rho;
+    double sinc = sin(c); double cosc = cos(c);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double lat_rad = asin(cosc*sinlat0 + (y*sinc*coslat0)/(rho==0?1:rho));
+    double lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc);
+    *lon = fmod(deg(lam)+clon+360.0,360.0);
+    *lat = deg(lat_rad);
+}
+
+void orthographic_projection(double clon, double clat, double lon, double lat, double *x, double *y){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    *x = coslat * sin(dlon);
+    *y = coslat0 * sinlat - sinlat0 * coslat * cos(dlon);
+}
+
+void inverse_orthographic_projection(double clon, double clat, double x, double y, double *lon, double *lat){
+    double rho = hypot(x,y);
+    if(rho>1) { *lon=NAN; *lat=NAN; return; }
+    double c = asin(rho);
+    double sinc = sin(c); double cosc = cos(c);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double lat_rad = asin(cosc*sinlat0 + (y*sinc*coslat0)/(rho==0?1:rho));
+    double lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc);
+    *lon = fmod(deg(lam)+clon+360.0,360.0);
+    *lat = deg(lat_rad);
+}
+
+#ifdef TEST
+int main(){
+    double x,y,lon,lat;
+    gnomonic_projection(0,90,120,45,&x,&y);
+    printf("gno %f %f\n",x,y);
+    inverse_gnomonic_projection(0,90,x,y,&lon,&lat);
+    printf("back %f %f\n",lon,lat);
+    return 0;
+}
+#endif

--- a/cpp/projections.cpp
+++ b/cpp/projections.cpp
@@ -1,0 +1,89 @@
+#include <cmath>
+#include <iostream>
+
+static double rad(double d){ return d * M_PI / 180.0; }
+static double deg(double r){ return r * 180.0 / M_PI; }
+
+struct Point { double x, y; };
+struct Spherical { double lon, lat; };
+
+Point gnomonic_projection(double clon, double clat, double lon, double lat){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    double denom = sinlat*sinlat0 + coslat*coslat0*cos(dlon);
+    Point p;
+    p.x = coslat * sin(dlon) / denom;
+    p.y = (sinlat*coslat0 - coslat*sinlat0*cos(dlon)) / denom;
+    return p;
+}
+
+Spherical inverse_gnomonic_projection(double clon, double clat, double x, double y){
+    double lat0 = rad(clat);
+    double sinlat0 = sin(lat0);
+    double coslat0 = cos(lat0);
+    double denom = coslat0 - y*sinlat0;
+    double lam = atan2(x, denom);
+    Spherical s;
+    s.lon = fmod(deg(lam)+clon+360.0,360.0);
+    double numerator = (y*coslat0 + sinlat0)*cos(lam);
+    s.lat = deg(atan(numerator/denom));
+    return s;
+}
+
+Point azimuthal_equidistant_projection(double clon, double clat, double lon, double lat){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    double cosc = sinlat0*sinlat + coslat0*coslat*cos(dlon);
+    cosc = std::min(1.0, std::max(-1.0, cosc));
+    double c = acos(cosc);
+    double k = (c!=0.0)? c/sin(c):1.0;
+    Point p; p.x = k*coslat*sin(dlon); p.y = k*(coslat0*sinlat - sinlat0*coslat*cos(dlon));
+    return p;
+}
+
+Spherical inverse_azimuthal_equidistant_projection(double clon, double clat, double x, double y){
+    double rho = hypot(x,y); double c = rho;
+    double sinc = sin(c), cosc = cos(c);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    Spherical s;
+    s.lat = deg(asin(cosc*sinlat0 + (y*sinc*coslat0)/(rho==0?1:rho)));
+    double lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc);
+    s.lon = fmod(deg(lam)+clon+360.0,360.0);
+    return s;
+}
+
+Point orthographic_projection(double clon, double clat, double lon, double lat){
+    double dlon = rad(lon - clon);
+    double sinlat0 = sin(rad(clat));
+    double coslat0 = cos(rad(clat));
+    double sinlat = sin(rad(lat));
+    double coslat = cos(rad(lat));
+    Point p; p.x = coslat*sin(dlon); p.y = coslat0*sinlat - sinlat0*coslat*cos(dlon); return p; }
+
+Spherical inverse_orthographic_projection(double clon, double clat, double x, double y){
+    double rho = hypot(x,y);
+    if(rho>1) return {NAN,NAN};
+    double c = asin(rho); double sinc=sin(c), cosc=cos(c);
+    double sinlat0=sin(rad(clat)), coslat0=cos(rad(clat));
+    Spherical s;
+    s.lat = deg(asin(cosc*sinlat0 + (y*sinc*coslat0)/(rho==0?1:rho)));
+    double lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc);
+    s.lon = fmod(deg(lam)+clon+360.0,360.0);
+    return s;
+}
+
+#ifdef TEST
+int main(){
+    Point p = gnomonic_projection(0,90,120,45);
+    std::cout << "gno "<<p.x<<" "<<p.y<<"\n";
+    Spherical s = inverse_gnomonic_projection(0,90,p.x,p.y);
+    std::cout << "back "<<s.lon<<" "<<s.lat<<"\n";
+}
+#endif

--- a/fortran/projections.f90
+++ b/fortran/projections.f90
@@ -1,0 +1,120 @@
+module projections
+contains
+  real*8 function rad(d) result(r)
+    real*8, intent(in) :: d
+    r = d * acos(-1.0d0) / 180.0d0
+  end function rad
+
+  real*8 function deg(r)
+    real*8, intent(in) :: r
+    deg = r * 180.0d0 / acos(-1.0d0)
+  end function deg
+
+  subroutine gnomonic_projection(clon, clat, lon, lat, x, y)
+    real*8, intent(in) :: clon, clat, lon, lat
+    real*8, intent(out) :: x, y
+    real*8 dlon, sinlat0, coslat0, sinlat, coslat, denom
+    dlon = rad(lon - clon)
+    sinlat0 = sin(rad(clat))
+    coslat0 = cos(rad(clat))
+    sinlat = sin(rad(lat))
+    coslat = cos(rad(lat))
+    denom = sinlat*sinlat0 + coslat*coslat0*cos(dlon)
+    x = coslat*sin(dlon)/denom
+    y = (sinlat*coslat0 - coslat*sinlat0*cos(dlon))/denom
+  end subroutine gnomonic_projection
+
+  subroutine inverse_gnomonic_projection(clon, clat, x, y, lon, lat)
+    real*8, intent(in) :: clon, clat, x, y
+    real*8, intent(out) :: lon, lat
+    real*8 lat0, sinlat0, coslat0, denom, lam, num
+    lat0 = rad(clat)
+    sinlat0 = sin(lat0)
+    coslat0 = cos(lat0)
+    denom = coslat0 - y*sinlat0
+    lam = atan2(x, denom)
+    lon = mod(deg(lam)+clon+360.d0,360.d0)
+    num = (y*coslat0 + sinlat0)*cos(lam)
+    lat = deg(atan(num/denom))
+  end subroutine inverse_gnomonic_projection
+
+  subroutine azimuthal_equidistant_projection(clon, clat, lon, lat, x, y)
+    real*8, intent(in) :: clon, clat, lon, lat
+    real*8, intent(out) :: x, y
+    real*8 dlon, sinlat0, coslat0, sinlat, coslat, cosc, c, k
+    dlon = rad(lon - clon)
+    sinlat0 = sin(rad(clat))
+    coslat0 = cos(rad(clat))
+    sinlat = sin(rad(lat))
+    coslat = cos(rad(lat))
+    cosc = sinlat0*sinlat + coslat0*coslat*cos(dlon)
+    if(cosc > 1.d0) cosc=1.d0
+    if(cosc < -1.d0) cosc=-1.d0
+    c = acos(cosc)
+    if (c /= 0.d0) then
+       k = c / sin(c)
+    else
+       k = 1.d0
+    end if
+    x = k*coslat*sin(dlon)
+    y = k*(coslat0*sinlat - sinlat0*coslat*cos(dlon))
+  end subroutine azimuthal_equidistant_projection
+
+  subroutine inverse_azimuthal_equidistant_projection(clon, clat, x, y, lon, lat)
+    real*8, intent(in) :: clon, clat, x, y
+    real*8, intent(out) :: lon, lat
+    real*8 rho, c, sinc, cosc, sinlat0, coslat0, lam
+    rho = sqrt(x*x + y*y)
+    c = rho
+    sinc = sin(c)
+    cosc = cos(c)
+    sinlat0 = sin(rad(clat))
+    coslat0 = cos(rad(clat))
+    lat = deg(asin(cosc*sinlat0 + (y*sinc*coslat0)/(merge(rho,1.d0,rho==0.d0))))
+    lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc)
+    lon = mod(deg(lam)+clon+360.d0,360.d0)
+  end subroutine inverse_azimuthal_equidistant_projection
+
+  subroutine orthographic_projection(clon, clat, lon, lat, x, y)
+    real*8, intent(in) :: clon, clat, lon, lat
+    real*8, intent(out) :: x, y
+    real*8 dlon, sinlat0, coslat0, sinlat, coslat
+    dlon = rad(lon - clon)
+    sinlat0 = sin(rad(clat))
+    coslat0 = cos(rad(clat))
+    sinlat = sin(rad(lat))
+    coslat = cos(rad(lat))
+    x = coslat*sin(dlon)
+    y = coslat0*sinlat - sinlat0*coslat*cos(dlon)
+  end subroutine orthographic_projection
+
+  subroutine inverse_orthographic_projection(clon, clat, x, y, lon, lat)
+    real*8, intent(in) :: clon, clat, x, y
+    real*8, intent(out) :: lon, lat
+    real*8 rho, c, sinc, cosc, sinlat0, coslat0, lam
+    rho = sqrt(x*x + y*y)
+    if (rho > 1.d0) then
+       lon = 0.d0; lat = 0.d0; return
+    end if
+    c = asin(rho)
+    sinc = sin(c)
+    cosc = cos(c)
+    sinlat0 = sin(rad(clat))
+    coslat0 = cos(rad(clat))
+    lat = deg(asin(cosc*sinlat0 + (y*sinc*coslat0)/(merge(rho,1.d0,rho==0.d0))))
+    lam = atan2(x*sinc, rho*coslat0*cosc - y*sinlat0*sinc)
+    lon = mod(deg(lam)+clon+360.d0,360.d0)
+  end subroutine inverse_orthographic_projection
+
+end module projections
+
+#ifdef TEST
+program test
+  use projections
+  real*8 x,y,lon,lat
+  call gnomonic_projection(0.d0,90.d0,120.d0,45.d0,x,y)
+  print *, 'gno', x, y
+  call inverse_gnomonic_projection(0.d0,90.d0,x,y,lon,lat)
+  print *, 'back', lon, lat
+end program test
+#endif


### PR DESCRIPTION
## Summary
- add Python functions for azimuthal equidistant and orthographic projections
- expand README with bilingual explanation and usage
- provide reference C, C++ and Fortran implementations

## Testing
- `python3 -m py_compile Projections/az_eqd_ortho.py`


------
https://chatgpt.com/codex/tasks/task_e_68444afc6ccc83238ee822444b89c482