### PR TITLE
Add combined projections module and usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,21 @@ This repository demonstrates several azimuthal map projections used in astronomy
 All angles are in degrees.  The forward functions convert longitude and latitude into planar \(x, y\) coordinates relative to a chosen projection center.  The inverse functions recover spherical coordinates from those plane values.
 
 ```
-from Gnomonic.gnomonic import gnomonic_projection
-from Projections.az_eqd_ortho import azimuthal_equidistant_projection
+from projections import (
+    gnomonic_projection,
+    azimuthal_equidistant_projection,
+    orthographic_projection,
+)
 
 center_lon, center_lat = 0.0, 90.0
 lon, lat = [120.0], [45.0]
+
+# Project using the gnomonic projection
 xi, eta = gnomonic_projection(center_lon, center_lat, lon, lat)
 ```
+
+See `example_usage.py` for a complete demonstration that also
+exercises the inverse transforms.
 
 ### C/C++/Fortran
 

--- a/example_usage.py
+++ b/example_usage.py
@@ -1,0 +1,41 @@
+"""Example script demonstrating projections usage."""
+
+from projections import (
+    gnomonic_projection,
+    inverse_gnomonic_projection,
+    azimuthal_equidistant_projection,
+    inverse_azimuthal_equidistant_projection,
+    orthographic_projection,
+    inverse_orthographic_projection,
+)
+
+
+def main():
+    # Projection center at the north pole
+    center_lon, center_lat = 0.0, 90.0
+
+    # Example spherical coordinates to project
+    lon = [120.0, 40.0]
+    lat = [45.0, 10.0]
+
+    # Gnomonic
+    x, y = gnomonic_projection(center_lon, center_lat, lon, lat)
+    print("Gnomonic:", x, y)
+    lon2, lat2 = inverse_gnomonic_projection(center_lon, center_lat, x, y)
+    print("Recovered:", lon2, lat2)
+
+    # Azimuthal equidistant
+    x, y = azimuthal_equidistant_projection(center_lon, center_lat, lon, lat)
+    print("Azimuthal Equidistant:", x, y)
+    lon2, lat2 = inverse_azimuthal_equidistant_projection(center_lon, center_lat, x, y)
+    print("Recovered:", lon2, lat2)
+
+    # Orthographic
+    x, y = orthographic_projection(center_lon, center_lat, lon, lat)
+    print("Orthographic:", x, y)
+    lon2, lat2 = inverse_orthographic_projection(center_lon, center_lat, x, y)
+    print("Recovered:", lon2, lat2)
+
+
+if __name__ == "__main__":
+    main()

--- a/projections.py
+++ b/projections.py
@@ -1,0 +1,129 @@
+"""projections.py
+Combined implementations of gnomonic, azimuthal equidistant and
+orthographic projections with their inverse transforms.
+All angles are expected in degrees.
+"""
+
+import numpy as np
+
+# ----------------------------------------------------------------------
+# Gnomonic projection
+# ----------------------------------------------------------------------
+
+def gnomonic_projection(center_lon, center_lat, lon, lat):
+    """Project lon/lat to tangent plane using gnomonic projection.
+
+    Parameters
+    ----------
+    center_lon, center_lat : float
+        Longitude and latitude of the projection center in degrees.
+    lon, lat : array_like
+        Coordinates of points to project in degrees.
+
+    Returns
+    -------
+    x, y : ndarray
+        Coordinates on the tangent plane.
+    """
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+
+    dlon = np.radians((lon - center_lon + 180) % 360 - 180)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    sin_lat = np.sin(np.radians(lat))
+    cos_lat = np.cos(np.radians(lat))
+
+    denom = sin_lat * sin_lat0 + cos_lat * cos_lat0 * np.cos(dlon)
+    x = cos_lat * np.sin(dlon) / denom
+    y = (sin_lat * cos_lat0 - cos_lat * sin_lat0 * np.cos(dlon)) / denom
+    return x, y
+
+
+def inverse_gnomonic_projection(center_lon, center_lat, x, y):
+    """Recover lon/lat from gnomonic projection coordinates."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+
+    lat0_rad = np.radians(center_lat)
+    sin_lat0 = np.sin(lat0_rad)
+    cos_lat0 = np.cos(lat0_rad)
+
+    denom = cos_lat0 - y * sin_lat0
+    lam = np.arctan2(x, denom)
+    lon = (np.degrees(lam) + center_lon + 360) % 360
+    numerator = (y * cos_lat0 + sin_lat0) * np.cos(lam)
+    lat = np.degrees(np.arctan(numerator / denom))
+    return lon, lat
+
+# ----------------------------------------------------------------------
+# Azimuthal equidistant projection
+# ----------------------------------------------------------------------
+
+def azimuthal_equidistant_projection(center_lon, center_lat, lon, lat):
+    """Azimuthal equidistant projection."""
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+    dlon = np.radians((lon - center_lon + 180) % 360 - 180)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    sin_lat = np.sin(np.radians(lat))
+    cos_lat = np.cos(np.radians(lat))
+    cos_c = sin_lat0 * sin_lat + cos_lat0 * cos_lat * np.cos(dlon)
+    cos_c = np.clip(cos_c, -1.0, 1.0)
+    c = np.arccos(cos_c)
+    k = np.where(c != 0, c / np.sin(c), 1.0)
+    x = k * cos_lat * np.sin(dlon)
+    y = k * (cos_lat0 * sin_lat - sin_lat0 * cos_lat * np.cos(dlon))
+    return x, y
+
+
+def inverse_azimuthal_equidistant_projection(center_lon, center_lat, x, y):
+    """Inverse azimuthal equidistant projection."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    rho = np.hypot(x, y)
+    c = rho
+    sin_c = np.sin(c)
+    cos_c = np.cos(c)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    lat = np.arcsin(cos_c * sin_lat0 + (y * sin_c * cos_lat0) / np.where(rho != 0, rho, 1))
+    lon = np.radians(center_lon) + np.arctan2(x * sin_c, rho * cos_lat0 * cos_c - y * sin_lat0 * sin_c)
+    return (np.degrees(lon) + 360) % 360, np.degrees(lat)
+
+# ----------------------------------------------------------------------
+# Orthographic projection
+# ----------------------------------------------------------------------
+
+def orthographic_projection(center_lon, center_lat, lon, lat):
+    """Orthographic projection."""
+    lon = np.asarray(lon, dtype=float)
+    lat = np.asarray(lat, dtype=float)
+    dlon = np.radians((lon - center_lon + 180) % 360 - 180)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    sin_lat = np.sin(np.radians(lat))
+    cos_lat = np.cos(np.radians(lat))
+    x = cos_lat * np.sin(dlon)
+    y = cos_lat0 * sin_lat - sin_lat0 * cos_lat * np.cos(dlon)
+    return x, y
+
+
+def inverse_orthographic_projection(center_lon, center_lat, x, y):
+    """Inverse orthographic projection."""
+    x = np.asarray(x, dtype=float)
+    y = np.asarray(y, dtype=float)
+    rho = np.hypot(x, y)
+    if np.any(rho > 1):
+        # Points outside the visible hemisphere cannot be projected back
+        return np.full_like(x, np.nan), np.full_like(y, np.nan)
+    c = np.arcsin(np.clip(rho, -1.0, 1.0))
+    sin_c = np.sin(c)
+    cos_c = np.cos(c)
+    sin_lat0 = np.sin(np.radians(center_lat))
+    cos_lat0 = np.cos(np.radians(center_lat))
+    lat = np.arcsin(cos_c * sin_lat0 + (y * sin_c * cos_lat0) / np.where(rho != 0, rho, 1))
+    lon = np.radians(center_lon) + np.arctan2(x * sin_c, rho * cos_lat0 * cos_c - y * sin_lat0 * sin_c)
+    return (np.degrees(lon) + 360) % 360, np.degrees(lat)
+


### PR DESCRIPTION
## Summary
- provide `projections.py` with gnomonic, azimuthal equidistant and orthographic
- add `example_usage.py` showing how to call each projection
- update README to reference new module and example script

## Testing
- `python example_usage.py` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_684511b366e08323807a5c386954b0bc