### PR TITLE
Add cross-language projection tests

### DIFF
--- a/c/projections.c
+++ b/c/projections.c
@@ -6,8 +6,16 @@ static double rad(double d){ return d * M_PI / 180.0; }
 /* Convert radians to degrees */
 static double deg(double r){ return r * 180.0 / M_PI; }
 
+/* Difference of longitudes in radians normalized to [-pi, pi] */
+static double dlon_rad(double lon, double clon){
+    double d = fmod(lon - clon + 180.0, 360.0);
+    if(d < 0) d += 360.0;
+    d -= 180.0;
+    return rad(d);
+}
+
 void gnomonic_projection(double clon, double clat, double lon, double lat, double *x, double *y){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -29,7 +37,7 @@ void inverse_gnomonic_projection(double clon, double clat, double x, double y, d
 }
 
 void azimuthal_equidistant_projection(double clon, double clat, double lon, double lat, double *x, double *y){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -55,7 +63,7 @@ void inverse_azimuthal_equidistant_projection(double clon, double clat, double x
 }
 
 void orthographic_projection(double clon, double clat, double lon, double lat, double *x, double *y){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -80,10 +88,23 @@ void inverse_orthographic_projection(double clon, double clat, double x, double 
 #ifdef TEST
 int main(){
     double x,y,lon,lat;
+    /* Gnomonic */
     gnomonic_projection(0,90,120,45,&x,&y);
-    printf("gno %f %f\n",x,y);
+    printf("Gnomonic: %f %f\n",x,y);
     inverse_gnomonic_projection(0,90,x,y,&lon,&lat);
-    printf("back %f %f\n",lon,lat);
+    printf("Recovered: %f %f\n",lon,lat);
+
+    /* Azimuthal Equidistant */
+    azimuthal_equidistant_projection(0,90,120,45,&x,&y);
+    printf("Azimuthal Equidistant: %f %f\n",x,y);
+    inverse_azimuthal_equidistant_projection(0,90,x,y,&lon,&lat);
+    printf("Recovered: %f %f\n",lon,lat);
+
+    /* Orthographic */
+    orthographic_projection(0,90,120,45,&x,&y);
+    printf("Orthographic: %f %f\n",x,y);
+    inverse_orthographic_projection(0,90,x,y,&lon,&lat);
+    printf("Recovered: %f %f\n",lon,lat);
     return 0;
 }
 #endif

--- a/cpp/projections.cpp
+++ b/cpp/projections.cpp
@@ -4,11 +4,19 @@
 static double rad(double d){ return d * M_PI / 180.0; }
 static double deg(double r){ return r * 180.0 / M_PI; }
 
+// Difference of longitudes in radians normalized to [-pi, pi]
+static double dlon_rad(double lon, double clon){
+    double d = fmod(lon - clon + 180.0, 360.0);
+    if(d < 0) d += 360.0;
+    d -= 180.0;
+    return rad(d);
+}
+
 struct Point { double x, y; };
 struct Spherical { double lon, lat; };
 
 Point gnomonic_projection(double clon, double clat, double lon, double lat){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -34,7 +42,7 @@ Spherical inverse_gnomonic_projection(double clon, double clat, double x, double
 }
 
 Point azimuthal_equidistant_projection(double clon, double clat, double lon, double lat){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -60,7 +68,7 @@ Spherical inverse_azimuthal_equidistant_projection(double clon, double clat, dou
 }
 
 Point orthographic_projection(double clon, double clat, double lon, double lat){
-    double dlon = rad(lon - clon);
+    double dlon = dlon_rad(lon, clon);
     double sinlat0 = sin(rad(clat));
     double coslat0 = cos(rad(clat));
     double sinlat = sin(rad(lat));
@@ -81,9 +89,21 @@ Spherical inverse_orthographic_projection(double clon, double clat, double x, do
 
 #ifdef TEST
 int main(){
-    Point p = gnomonic_projection(0,90,120,45);
-    std::cout << "gno "<<p.x<<" "<<p.y<<"\n";
-    Spherical s = inverse_gnomonic_projection(0,90,p.x,p.y);
-    std::cout << "back "<<s.lon<<" "<<s.lat<<"\n";
+    Point p; Spherical s;
+
+    p = gnomonic_projection(0,90,120,45);
+    std::cout << "Gnomonic: "<<p.x<<" "<<p.y<<"\n";
+    s = inverse_gnomonic_projection(0,90,p.x,p.y);
+    std::cout << "Recovered: "<<s.lon<<" "<<s.lat<<"\n";
+
+    p = azimuthal_equidistant_projection(0,90,120,45);
+    std::cout << "Azimuthal Equidistant: "<<p.x<<" "<<p.y<<"\n";
+    s = inverse_azimuthal_equidistant_projection(0,90,p.x,p.y);
+    std::cout << "Recovered: "<<s.lon<<" "<<s.lat<<"\n";
+
+    p = orthographic_projection(0,90,120,45);
+    std::cout << "Orthographic: "<<p.x<<" "<<p.y<<"\n";
+    s = inverse_orthographic_projection(0,90,p.x,p.y);
+    std::cout << "Recovered: "<<s.lon<<" "<<s.lat<<"\n";
 }
 #endif

--- a/fortran/projections.f90
+++ b/fortran/projections.f90
@@ -14,7 +14,7 @@ contains
     real*8, intent(in) :: clon, clat, lon, lat
     real*8, intent(out) :: x, y
     real*8 dlon, sinlat0, coslat0, sinlat, coslat, denom
-    dlon = rad(lon - clon)
+    dlon = rad(mod(lon - clon + 180.d0, 360.d0) - 180.d0)
     sinlat0 = sin(rad(clat))
     coslat0 = cos(rad(clat))
     sinlat = sin(rad(lat))
@@ -42,7 +42,7 @@ contains
     real*8, intent(in) :: clon, clat, lon, lat
     real*8, intent(out) :: x, y
     real*8 dlon, sinlat0, coslat0, sinlat, coslat, cosc, c, k
-    dlon = rad(lon - clon)
+    dlon = rad(mod(lon - clon + 180.d0, 360.d0) - 180.d0)
     sinlat0 = sin(rad(clat))
     coslat0 = cos(rad(clat))
     sinlat = sin(rad(lat))
@@ -79,7 +79,7 @@ contains
     real*8, intent(in) :: clon, clat, lon, lat
     real*8, intent(out) :: x, y
     real*8 dlon, sinlat0, coslat0, sinlat, coslat
-    dlon = rad(lon - clon)
+    dlon = rad(mod(lon - clon + 180.d0, 360.d0) - 180.d0)
     sinlat0 = sin(rad(clat))
     coslat0 = cos(rad(clat))
     sinlat = sin(rad(lat))
@@ -112,9 +112,23 @@ end module projections
 program test
   use projections
   real*8 x,y,lon,lat
+
+  ! Gnomonic
   call gnomonic_projection(0.d0,90.d0,120.d0,45.d0,x,y)
-  print *, 'gno', x, y
+  print *, 'Gnomonic:', x, y
   call inverse_gnomonic_projection(0.d0,90.d0,x,y,lon,lat)
-  print *, 'back', lon, lat
+  print *, 'Recovered:', lon, lat
+
+  ! Azimuthal Equidistant
+  call azimuthal_equidistant_projection(0.d0,90.d0,120.d0,45.d0,x,y)
+  print *, 'Azimuthal Equidistant:', x, y
+  call inverse_azimuthal_equidistant_projection(0.d0,90.d0,x,y,lon,lat)
+  print *, 'Recovered:', lon, lat
+
+  ! Orthographic
+  call orthographic_projection(0.d0,90.d0,120.d0,45.d0,x,y)
+  print *, 'Orthographic:', x, y
+  call inverse_orthographic_projection(0.d0,90.d0,x,y,lon,lat)
+  print *, 'Recovered:', lon, lat
 end program test
 #endif


### PR DESCRIPTION
## Summary
- normalize longitude differences in C/C++/Fortran implementations
- expand test programs for all projections and inverse transforms

## Testing
- `gcc c/projections.c -lm -DTEST -o c/test_c && ./c/test_c`
- `g++ cpp/projections.cpp -lm -DTEST -o cpp/test_cpp && ./cpp/test_cpp`
- `gfortran fortran/projections.f90 -DTEST -o fortran/test_f && ./fortran/test_f` *(fails: gfortran not found)*

------
https://chatgpt.com/codex/tasks/task_e_684518b1bc4c832382f8d1bc5e1fc5bb